### PR TITLE
Fix removal of multiple items from alias array

### DIFF
--- a/StubModule.js
+++ b/StubModule.js
@@ -49,12 +49,17 @@ function (
         });
 
         // remove stub aliases
+        var removedIndexs = [];
         array.forEach(require.aliases, function (al, i) {
             if (array.some(clonedAliases, function (cAl) {
                 return al[0].test(cAl[0]);
             })) {
-                require.aliases.splice(i, 1);
+                removedIndexs.unshift(i);
             }
+        });
+
+        array.forEach(removedIndexs, function(i) {
+            require.aliases.splice(i,1);
         });
 
         // clear cache again


### PR DESCRIPTION
Removing items from an array which is being iterated orver does not
work.  Storing items and removing them after all removed indexes are
determined.
